### PR TITLE
Question : OrderApiController class - orderV3 fetch join

### DIFF
--- a/src/main/java/jpabook/jpashop/api/OrderApiController.java
+++ b/src/main/java/jpabook/jpashop/api/OrderApiController.java
@@ -1,0 +1,119 @@
+package jpabook.jpashop.api;
+
+import jpabook.jpashop.domain.Address;
+import jpabook.jpashop.domain.Order;
+import jpabook.jpashop.domain.OrderItem;
+import jpabook.jpashop.domain.OrderStatus;
+import jpabook.jpashop.repository.OrderRepository;
+import jpabook.jpashop.repository.OrderSearch;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequiredArgsConstructor
+public class OrderApiController {
+
+    private final OrderRepository orderRepository;
+
+    /**
+     * v1. 엔티티 직접 노출
+     */
+    @GetMapping("/api/v1/orders")
+    public List<Order> ordersV1() {
+        List<Order> all = orderRepository.findAllByString(new OrderSearch());
+        for (Order order : all) {
+            order.getMember().getName();
+            order.getDelivery().getAddress();
+
+            List<OrderItem> orderItems = order.getOrderItems();
+            orderItems.stream().forEach(o -> o.getItem().getName());
+        }
+        return all;
+    }
+
+    /**
+     * v2. 엔티티를 조회해서 DTO로 변환
+     */
+    @GetMapping("/api/v2/orders")
+    public List<OrderDto> ordersV2() {
+        List<Order> orders = orderRepository.findAllByString(new OrderSearch());
+        List<OrderDto> result = orders.stream()
+                .map(o -> new OrderDto(o))
+                .collect(Collectors.toList());
+
+        return result;
+    }
+
+
+    /**
+     * v3. 엔티티를 조회해서 DTO로 변환 (fetch join 사용)
+     */
+    @GetMapping("/api/v3/orders")
+    public List<OrderDto> ordersV3() {
+        List<Order> orders = orderRepository.findAllWithItem();
+        List<OrderDto> result = orders.stream()
+                .map(o -> new OrderDto(o))
+                .collect(Collectors.toList());
+
+        return result;
+    }
+
+    @GetMapping("/api/v4/orders")
+    public List<Order> ordersV4() {
+        return null;
+    }
+
+    @GetMapping("/api/v5/orders")
+    public List<Order> ordersV5() {
+        return null;
+    }
+
+    @GetMapping("/api/v6/orders")
+    public List<Order> ordersV6() {
+        return null;
+    }
+
+
+    @Getter
+    static class OrderDto {
+
+        private Long orderId;
+        private String name;
+        private LocalDateTime orderDate;
+        private OrderStatus orderStatus;
+        private Address address;
+        private List<OrderItemDto> orderItems;
+
+        public OrderDto(Order order) {
+            orderId = order.getId();
+            name = order.getMember().getName();
+            orderDate = order.getOrderDate();
+            orderStatus = order.getStatus();
+            address = order.getDelivery().getAddress();
+            orderItems = order.getOrderItems().stream()
+                    .map(orderItem -> new OrderItemDto(orderItem))
+                    .collect(Collectors.toList());
+        }
+    }
+
+    @Getter
+    static class OrderItemDto {
+
+        private String itemName;
+        private int orderPrice;
+        private int count;
+
+        public OrderItemDto(OrderItem orderItem) {
+            itemName = orderItem.getItem().getName();
+            orderPrice = orderItem.getOrderPrice();
+            count = orderItem.getCount();
+        }
+    }
+
+}

--- a/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
+++ b/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
@@ -49,6 +49,16 @@ public class OrderSimpleApiController {
         return result;
     }
 
+    @GetMapping("/api/v3/simple-orders")
+    public List<SimpleOrderDto> ordersV3() {
+        List<Order> orders = orderRepository.findAllWithMemberDelivery();
+        List<SimpleOrderDto> result = orders.stream()
+                .map(o -> new SimpleOrderDto(o))
+                .collect(toList());
+
+        return result;
+    }
+
     @Data
     public static class SimpleOrderDto {
         private Long orderId;

--- a/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
+++ b/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
@@ -5,6 +5,8 @@ import jpabook.jpashop.domain.Order;
 import jpabook.jpashop.domain.OrderStatus;
 import jpabook.jpashop.repository.OrderRepository;
 import jpabook.jpashop.repository.OrderSearch;
+import jpabook.jpashop.repository.order.simplequery.OrderSimpleQueryDto;
+import jpabook.jpashop.repository.order.simplequery.OrderSimpleQueryRepository;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,7 +14,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.*;
 
@@ -27,6 +28,7 @@ import static java.util.stream.Collectors.*;
 public class OrderSimpleApiController {
 
     private final OrderRepository orderRepository;
+    private final OrderSimpleQueryRepository orderSimpleQueryRepository;
 
     @GetMapping("/api/v1/simple-orders")
     public List<Order> ordersV1() {
@@ -57,6 +59,11 @@ public class OrderSimpleApiController {
                 .collect(toList());
 
         return result;
+    }
+
+    @GetMapping("/api/v4/simple-orders")
+    public List<OrderSimpleQueryDto> ordersV4() {
+        return orderSimpleQueryRepository.findOrderDtos();
     }
 
     @Data

--- a/src/main/java/jpabook/jpashop/repository/OrderRepository.java
+++ b/src/main/java/jpabook/jpashop/repository/OrderRepository.java
@@ -96,4 +96,11 @@ public class OrderRepository {
     }
 
 
+    public List<Order> findAllWithMemberDelivery() {
+        return em.createQuery(
+                "select o from Order o" +
+                    " join fetch o.member m" +
+                    " join fetch o.delivery d", Order.class
+        ).getResultList();
+    }
 }

--- a/src/main/java/jpabook/jpashop/repository/OrderRepository.java
+++ b/src/main/java/jpabook/jpashop/repository/OrderRepository.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 @Repository
@@ -103,4 +104,7 @@ public class OrderRepository {
                     " join fetch o.delivery d", Order.class
         ).getResultList();
     }
+
+
+
 }

--- a/src/main/java/jpabook/jpashop/repository/OrderRepository.java
+++ b/src/main/java/jpabook/jpashop/repository/OrderRepository.java
@@ -106,5 +106,13 @@ public class OrderRepository {
     }
 
 
-
+    public List<Order> findAllWithItem() {
+        return em.createQuery(
+                    "select o from Order o" +
+                    " join fetch o.member m" +
+                    " join fetch o.delivery d" +
+                    " join fetch o.orderItems oi" +
+                    " join fetch oi.item i", Order.class)
+                .getResultList();
+    }
 }

--- a/src/main/java/jpabook/jpashop/repository/order/simplequery/OrderSimpleQueryDto.java
+++ b/src/main/java/jpabook/jpashop/repository/order/simplequery/OrderSimpleQueryDto.java
@@ -1,0 +1,25 @@
+package jpabook.jpashop.repository.order.simplequery;
+
+import jpabook.jpashop.domain.Address;
+import jpabook.jpashop.domain.OrderStatus;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class OrderSimpleQueryDto {
+
+    private Long orderId;
+    private String name;
+    private LocalDateTime orderDate;
+    private OrderStatus orderStatus;
+    private Address address;
+
+    public OrderSimpleQueryDto(Long orderId, String name, LocalDateTime orderDate, OrderStatus orderStatus, Address address) {
+        this.orderId = orderId;
+        this.name = name;
+        this.orderDate = orderDate;
+        this.orderStatus = orderStatus;
+        this.address = address;
+    }
+}

--- a/src/main/java/jpabook/jpashop/repository/order/simplequery/OrderSimpleQueryRepository.java
+++ b/src/main/java/jpabook/jpashop/repository/order/simplequery/OrderSimpleQueryRepository.java
@@ -1,0 +1,23 @@
+package jpabook.jpashop.repository.order.simplequery;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderSimpleQueryRepository {
+
+    private final EntityManager em;
+
+    public List<OrderSimpleQueryDto> findOrderDtos() {
+        return em.createQuery(
+                        "select new jpabook.jpashop.repository.order.simplequery.OrderSimpleQueryDto(o.id, m.name, o.orderDate, o.status, d.address) " +
+                                " from Order o" +
+                                " join o.member m" +
+                                " join o.delivery d", OrderSimpleQueryDto.class)
+                .getResultList();
+    }
+}


### PR DESCRIPTION
orderItems와 order 테이블을 join 할 때, order는 2개 뿐이지만 orderItems가 4개라서 join된 테이블 및 JSON은 중복되는 order가 2개씩 총 4개 나와야 하는데, 실제 확인 결과 JSON에서는 중복되는 order가 존재하지 않았습니다.

예를 들어, JSON으로 다음과 같은 내용이 orderId 1인 경우 2개, 2인 경우 2개씩 총 4개가 나와야 했지만 (예상된 결과)
각각 1개씩 총 2개밖에 나오지 않았습니다. (실제 결과)

{
        "orderId": 1,

        // ... 고객 정보

        "orderItems": [
            {
                   // ... item1 정보
            },
            {
                   // ... item2 정보
            }
        ]
}

왜 이런 결과가 나오는지 궁금합니다.